### PR TITLE
bug fixes for model replication

### DIFF
--- a/replicate_results/multilingual_paper/README.md
+++ b/replicate_results/multilingual_paper/README.md
@@ -91,7 +91,8 @@ fairseq-train \
     --eval-bleu-detok moses \
     --eval-bleu-remove-bpe \
     --eval-bleu-print-samples \
-    --best-checkpoint-metric bleu --maximize-best-checkpoint-metric
+    --best-checkpoint-metric bleu --maximize-best-checkpoint-metric \
+    --skip-invalid-size-inputs-valid-test
 ```
 9. Test your models
 ```

--- a/replicate_results/multilingual_paper/scripts/download_data.py
+++ b/replicate_results/multilingual_paper/scripts/download_data.py
@@ -51,7 +51,7 @@ if __name__ == "__main__":
     if not source and not target:
         response = input("The object you are attempting to download is more than 40 gigabytes. Are you sure you want to download it (\"Y\" or \"N\")?
         if response in ["Y", "y", "yes", "Yes"]:
-            download_url("", "./")
+            download_url(base_url, "./")
         else:
             print("Dowload has been cancelled!")
             quit()


### PR DESCRIPTION
base_url needs to be passed to download_url, else the url string is invalid. Passing --skip-invalid-size-inputs-valid-test to fairseq prevents training from crashing if an example is too long.